### PR TITLE
change type convering for `:lngs` from `to_i` to `to_f` for more prec…

### DIFF
--- a/lib/geo/coord.rb
+++ b/lib/geo/coord.rb
@@ -628,12 +628,12 @@ module Geo
       lat = (
         opts[:latd].to_i +
         opts[:latm].to_i / 60.0 +
-        opts[:lats].to_i / 3600.0
+        opts[:lats].to_f / 3600.0
       ) * guess_sign(opts[:lath], LATH)
       lng = (
         opts[:lngd].to_i +
         opts[:lngm].to_i / 60.0 +
-        opts[:lngs].to_i / 3600.0
+        opts[:lngs].to_f / 3600.0
       ) * guess_sign(opts[:lngh], LNGH)
       _init(lat, lng)
     end


### PR DESCRIPTION
…ise result

# Context
it's related to issue #9.

this PR fixes the precision of DMS to DD converting calculation.

**so, it changes the `:lats` and `:lngs` type casting manner to `to_f` instead of `to_i`**